### PR TITLE
Add dtor to Feature to prevent destruction problems

### DIFF
--- a/features.hpp
+++ b/features.hpp
@@ -12,6 +12,8 @@ public:
     Feature(Scale *s) : s(s){};
 
     virtual float getValue(size_t i) = 0;
+    virtual ~Feature() = default;
+
     std::string getName() const { return name; }
 
     void setName(const std::string &name){


### PR DESCRIPTION
> classifier.hpp:105:50: warning: delete called on 'Feature' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]